### PR TITLE
Change incorrect char.GetNumericValue references

### DIFF
--- a/Ch 01. Arrays and Strings/Q1_04_Palindrome_Permutation.cs
+++ b/Ch 01. Arrays and Strings/Q1_04_Palindrome_Permutation.cs
@@ -7,20 +7,16 @@ namespace Chapter01
     {
         public static int GetCharNumber(char c)
         {
-            var a = (int)char.GetNumericValue('a');
-            var z = (int)char.GetNumericValue('z');
-
-            var val = (int)char.GetNumericValue(c);
-            if (a <= val && val <= z)
+            if ('a' <= c && c <= 'z')
             {
-                return val - a;
+                return c - 'a';
             }
             return -1;
         }
 
         public static int[] BuildCharFrequencyTable(String phrase)
         {
-            int[] table = new int[(int)char.GetNumericValue('z') - (int)char.GetNumericValue('a') + 1];
+            int[] table = new int['z' - 'a' + 1];
             foreach (char c in phrase.ToCharArray())
             {
                 int x = GetCharNumber(c);


### PR DESCRIPTION
(int)char.GetNumericValue gets the numeric equivalent of a character...i.e. '1' becomes the integer 1 and 'a' or any other letter becomes -1. What you want instead is just the char value itself, which already has an ASCII integer associated with it....i.e. 'a' is 97, 'b' is 98, etc. 

The way you have this coded now, (int)char.GetNumericValue always returns -1 and the code makes no sense in Solution 1.